### PR TITLE
Appender and dependency to send log to GrayLog

### DIFF
--- a/sources/modules/control-panel/pom.xml
+++ b/sources/modules/control-panel/pom.xml
@@ -410,6 +410,26 @@
 			<version>2.5.6</version>
 		</dependency>
 
+
+	<!-- 	<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>1.2.17</version>
+		</dependency>  
+		
+		<dependency>
+			<groupId>org.graylog2</groupId>
+			<artifactId>gelfj</artifactId>
+			<version>1.1.15</version>
+		</dependency>-->
+
+		<dependency>
+		    <groupId>de.siegmar</groupId>
+		    <artifactId>logback-gelf</artifactId>
+		    <version>2.1.0</version>
+		</dependency>
+
+		
 	</dependencies>
 
 	<repositories>

--- a/sources/modules/control-panel/src/main/resources/logback-spring.xml
+++ b/sources/modules/control-panel/src/main/resources/logback-spring.xml
@@ -71,9 +71,7 @@
             </fullPatternLayout>
             <numbersAsString>false</numbersAsString>
             <staticField>app_name:control_panel</staticField>
-            <staticField>os_arch:${os.arch}</staticField>
             <staticField>os_name:${os.name}</staticField>
-            <staticField>os_version:${os.version}</staticField>
         </encoder>
     </appender>
 

--- a/sources/modules/control-panel/src/main/resources/logback-spring.xml
+++ b/sources/modules/control-panel/src/main/resources/logback-spring.xml
@@ -45,16 +45,57 @@
     <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
         <appender-ref ref="rollingFileAppender" />
     </appender>
+    
+    <appender name="GELF" class="de.siegmar.logbackgelf.GelfTcpAppender">
+        <graylogHost>127.0.0.1</graylogHost>
+        <graylogPort>12201</graylogPort>
+        <connectTimeout>15000</connectTimeout>
+        <reconnectInterval>300</reconnectInterval>
+        <maxRetries>2</maxRetries>
+        <retryDelay>3000</retryDelay>
+        <poolSize>2</poolSize>
+        <poolMaxWaitTime>5000</poolMaxWaitTime>
+        <encoder class="de.siegmar.logbackgelf.GelfEncoder">
+            <originHost>${HOSTNAME}</originHost>
+            <includeRawMessage>false</includeRawMessage>
+            <includeMarker>true</includeMarker>
+            <includeMdcData>true</includeMdcData>
+            <includeCallerData>true</includeCallerData>
+            <includeRootCauseData>true</includeRootCauseData>
+            <includeLevelName>true</includeLevelName>
+            <shortPatternLayout class="ch.qos.logback.classic.PatternLayout">
+                <pattern>%m%nopex</pattern>
+            </shortPatternLayout>
+            <fullPatternLayout class="ch.qos.logback.classic.PatternLayout">
+                <pattern>%m%n</pattern>
+            </fullPatternLayout>
+            <numbersAsString>false</numbersAsString>
+            <staticField>app_name:control_panel</staticField>
+            <staticField>os_arch:${os.arch}</staticField>
+            <staticField>os_name:${os.name}</staticField>
+            <staticField>os_version:${os.version}</staticField>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC GELF" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="GELF" />
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="ASYNC GELF" />
+    </root>    
          
     <springProfile name="dev,default">
 	    <root level="INFO">
 	        <appender-ref ref="stdoutAppender" />
 	        <appender-ref ref="rollingFileAppender" />
+	        <appender-ref ref="ASYNC GELF" />
 	    </root>
     </springProfile>
     <springProfile name="production,docker">
 	    <root level="INFO">
 	        <appender-ref ref="ASYNC" />
+	        <appender-ref ref="ASYNC GELF" />
 	    </root>
     </springProfile>     
     


### PR DESCRIPTION
For start the appender and dependency are only in the control-panel module.
The next step is to insert some constants into greylog module to use them into appender, and then clone the appender inside the other modules.
